### PR TITLE
Use `crossbeam_utils::CachePadded` instead of manually aligning

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,3 +9,6 @@ repository = "https://github.com/ashvardanian/fork_union"
 
 [lib]
 path = "fork_union.rs"
+
+[dependencies]
+crossbeam-utils = "0.8.21"


### PR DESCRIPTION
Rename `Padded64` -> `Padded` and use `crossbeam_utils::CachePadded` inside the cell and perform related cleanups.
`crossbeam_utils::CachePadded` still decays into `#[repr(align(N))]` but it does so based on the target architecture.

Small clippy fixes included.