### PR TITLE
Stress Test & Fix Race Conditions

### DIFF
--- a/include/fork_union.hpp
+++ b/include/fork_union.hpp
@@ -441,7 +441,7 @@ class fork_union {
             // If we run this loop at 1 Billion times per second on a 64-bit machine, then every 585 years
             // of computational time we will wrap around the `std::size_t` capacity for the `new_task_index`.
             // In case we `task_parts_count + thread_index >= std::size_t(-1)`, a simple condition won't be enough.
-            bool const beyond_task_and_overflow = task_parts_count < last_executed_task_in_this_thread;
+            bool const beyond_task_and_overflow = new_task_index < last_executed_task_in_this_thread;
             if (beyond_task_and_overflow) [[unlikely]]
                 break;
 

--- a/include/fork_union.hpp
+++ b/include/fork_union.hpp
@@ -57,6 +57,11 @@ static constexpr std::size_t default_alignment_k = alignof(std::max_align_t);
  *  Note, that for N-wide parallelism, it initiates (N-1) threads, and the current caller thread
  *  is also executing tasks. The number of threads is fixed and cannot be changed.
  *
+ *  Note, the pool is not re-entrant! So you can't recursively submit new tasks!
+ *
+ *  Note, the pool can't be copied or moved, as it's worker threads depend on the address
+ *  of the parent structure, spawning them.
+ *
  *  It avoids heap allocations and expensive abstractions like `std::function`, `std::future`,
  *  `std::promise`, `std::condition_variable`, etc. It only uses `std::thread` and `std::atomic`,
  *  benefiting from the fact, that those are standardized since C++11.


### PR DESCRIPTION
I've added an additional template parameter in the C++ version - `index_type_`, which allows overriding the `std::size_t` as the default indexing type to emulate very unlikely conditions of integer overflows. It helped locate several issues, related to #5.