### PR TITLE
Safe broadcast

### DIFF
--- a/scripts/nbody.rs
+++ b/scripts/nbody.rs
@@ -110,7 +110,7 @@ fn hw_threads() -> usize {
 // ────────────────────────────────────────────────────────────────────────────
 // Fork-Union kernels
 // ────────────────────────────────────────────────────────────────────────────
-fn iteration_fu_static(pool: &fu::ThreadPool, bodies: &mut [Body], forces: &mut [Vector3]) {
+fn iteration_fu_static(pool: &mut fu::ThreadPool, bodies: &mut [Body], forces: &mut [Vector3]) {
     let n = bodies.len();
     let bodies_ptr = fu::SyncConstPtr::new(bodies.as_ptr());
 
@@ -129,7 +129,7 @@ fn iteration_fu_static(pool: &fu::ThreadPool, bodies: &mut [Body], forces: &mut 
     });
 }
 
-fn iteration_fu_dynamic(pool: &fu::ThreadPool, bodies: &mut [Body], forces: &mut [Vector3]) {
+fn iteration_fu_dynamic(pool: &mut fu::ThreadPool, bodies: &mut [Body], forces: &mut [Vector3]) {
     let n = bodies.len();
     let bodies_ptr = fu::SyncConstPtr::new(bodies.as_ptr());
 
@@ -254,17 +254,17 @@ fn main() -> Result<(), Box<dyn Error>> {
     // Run the chosen backend
     match backend.as_str() {
         "fork_union_static" => {
-            let pool = fu::ThreadPool::try_spawn(threads)
+            let mut pool = fu::ThreadPool::try_spawn(threads)
                 .unwrap_or_else(|e| panic!("Failed to start Fork-Union pool: {e}"));
             for _ in 0..iters {
-                iteration_fu_static(&pool, &mut bodies, &mut forces);
+                iteration_fu_static(&mut pool, &mut bodies, &mut forces);
             }
         }
         "fork_union_dynamic" => {
-            let pool = fu::ThreadPool::try_spawn(threads)
+            let mut pool = fu::ThreadPool::try_spawn(threads)
                 .unwrap_or_else(|e| panic!("Failed to start Fork-Union pool: {e}"));
             for _ in 0..iters {
-                iteration_fu_dynamic(&pool, &mut bodies, &mut forces);
+                iteration_fu_dynamic(&mut pool, &mut bodies, &mut forces);
             }
         }
         "rayon_static" => {


### PR DESCRIPTION
Changed the API of `ThreadPool::broadcast` to take `&mut self` instead of `&self`. This is done to get compile time exclusivity, so
we can prevent concurrent broadcasts at compile time not for mutability. This will prevent the datarace mentioned in https://github.com/ashvardanian/fork_union/issues/13

Call sites are accordingly to changed to `let mut pool =`  and `&mut pool.

After this the following test will fail to compile while it passes on current `main`.
```rust
#[test]
fn test_concurrent_broadcast() {
    let mut pool = spawn(4);

    thread::scope(|s| {
        s.spawn(|| {
            pool.broadcast(|i| println!("A: {}", i));
        });

        s.spawn(|| {
            pool.broadcast(|i| println!("B: {}", i));
        });
    });
}
```

Closes: https://github.com/ashvardanian/fork_union/issues/13