### PR TITLE
Add a FORK_UNION_BUILD_TESTS option to the cmake

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -224,7 +224,10 @@ endif ()
 
 # Tests & benchmarking scripts
 include(CTest)
-if (BUILD_TESTING)
+
+option(FORK_UNION_BUILD_TESTS "Build fork_union tests" ON)
+
+if (BUILD_TESTING AND FORK_UNION_BUILD_TESTS)
     enable_testing()
     add_subdirectory(scripts)
 endif ()


### PR DESCRIPTION
This enables project that includes fork_union with the `fetch_content` method listed in `README.md` to disable fork_union's test while still enabling CTest for their project.

(I'm a beginner in CMake, if there's a better way to do this I'll gladly take suggestions)