### PR TITLE
Feat/interruptible worker sleep

### DIFF
--- a/c/forkunion.cpp
+++ b/c/forkunion.cpp
@@ -234,9 +234,11 @@ void visit(visitor_type_ &&visitor, pool_variants_t &variants) {
  */
 template <fu::pool_kind_t pool_kind_, typename... args_types_>
 static void construct_pool(pool_variants_t &variants, fu::capabilities_t effective, args_types_ &&...args) noexcept {
+    bool const interruptible_sleep = effective & fu::capability_interruptible_sleep_k;
     select_pool<pool_kind_>(effective, [&](auto tag) {
         using pool_t = typename decltype(tag)::type;
-        variants.construct<pool_t>(std::forward<args_types_>(args)...);
+        variants.construct<pool_t>(std::forward<args_types_>(args)..., interruptible_sleep);
+        if (interruptible_sleep) variants.capabilities_ |= fu::capability_interruptible_sleep_k;
     });
 }
 
@@ -328,6 +330,7 @@ fu_assert_same_bit_(fu_capability_place_memory_on_domain_k, capability_place_mem
 fu_assert_same_bit_(fu_capability_place_huge_pages_on_domain_k, capability_place_huge_pages_on_domain_k);
 fu_assert_same_bit_(fu_capability_huge_transparent_pages_k, capability_huge_transparent_pages_k);
 fu_assert_same_bit_(fu_capability_colocate_pools_on_domain_k, capability_colocate_pools_on_domain_k);
+fu_assert_same_bit_(fu_capability_interruptible_sleep_k, capability_interruptible_sleep_k);
 
 #undef fu_assert_same_bit_
 
@@ -556,8 +559,10 @@ inline void fu_aligned_free(void *ptr, std::size_t alignment) noexcept {
 }
 
 fu_pool_t fu_pool_new(FU_MAYBE_UNUSED_ char const *name, fu_capabilities_t allowed) {
-    fu::capabilities_t const effective =
+    fu::capabilities_t effective =
         static_cast<fu::capabilities_t>(machine_capabilities() & static_cast<fu::capabilities_t>(allowed));
+    if (FU_DETECT_ATOMIC_WAIT_ && (allowed & fu_capability_interruptible_sleep_k))
+        effective |= fu::capability_interruptible_sleep_k;
     opaque_pool_t *opaque =
         static_cast<opaque_pool_t *>(fu_aligned_malloc(sizeof(opaque_pool_t), alignof(opaque_pool_t)));
     if (!opaque) return nullptr;

--- a/include/forkunion.h
+++ b/include/forkunion.h
@@ -211,6 +211,8 @@ typedef enum fu_capabilities_t {
     /** The kernel enabled user-mode Zicbom cache-block management, attested through `hwprobe` -
      *  the hook for a future runtime-dispatched `cbo.clean`; nothing emits it yet. */
     fu_capability_risc5_zicbom_k = 1 << 17,
+    /** Sleeping workers wait for a dispatch notification instead of polling. Built with C++20 atomics support. */
+    fu_capability_interruptible_sleep_k = 1 << 18,
 
     /** Composite mask of every busy-wait waiter bit above, to enumerate the ones a machine offers. */
     fu_capability_any_yield_k = fu_capability_x86_pause_k | fu_capability_x86_tpause_k | fu_capability_arm64_yield_k |
@@ -622,8 +624,8 @@ size_t fu_pool_locate_thread_in(fu_pool_t pool, size_t global_thread_index, size
  *  @param[in] micros Maximum fallback wake interval in microseconds, must be > 0.
  *  @note Not thread-safe; call between task batches.
  *
- *  C++20 builds wake workers directly on the next dispatch. C++17 builds poll at @p micros; on Linux
- *  sleeping threads are also de-prioritized with the scheduler.
+ *  Workers wake directly when the pool was created with `fu_capability_interruptible_sleep_k` in
+ *  its allowed mask; otherwise they poll at @p micros. On Linux, sleepers are also de-prioritized.
  */
 void fu_pool_sleep(fu_pool_t pool, size_t micros);
 

--- a/include/forkunion.h
+++ b/include/forkunion.h
@@ -617,13 +617,13 @@ size_t fu_pool_threads_count(fu_pool_t pool);
 size_t fu_pool_locate_thread_in(fu_pool_t pool, size_t global_thread_index, size_t compute_domain_index);
 
 /**
- *  @brief Parks idle workers in a low-power sleep, re-checking for work every @p micros.
+ *  @brief Parks idle workers in a low-power sleep until the next dispatch.
  *  @param[in] pool Pool handle, must not be NULL.
- *  @param[in] micros Wake-up poll interval in microseconds, must be > 0.
- *  @note Not thread-safe; call between task batches. The next dispatch wakes the workers.
+ *  @param[in] micros Maximum fallback wake interval in microseconds, must be > 0.
+ *  @note Not thread-safe; call between task batches.
  *
- *  Trades up to @p micros of startup latency for lower power draw during long idle periods; on Linux
- *  it also de-prioritizes the sleeping threads with the scheduler.
+ *  C++20 builds wake workers directly on the next dispatch. C++17 builds poll at @p micros; on Linux
+ *  sleeping threads are also de-prioritized with the scheduler.
  */
 void fu_pool_sleep(fu_pool_t pool, size_t micros);
 

--- a/include/forkunion/capabilities.hpp
+++ b/include/forkunion/capabilities.hpp
@@ -867,7 +867,8 @@ constexpr capabilities_t comptime_capabilities() noexcept {
         (FU_WITH_RESCHEDULE_THREADS_BY_CLASS ? capability_reschedule_threads_by_class_k : capabilities_unknown_k) |
         (FU_WITH_PLACE_MEMORY_ON_DOMAIN ? capability_place_memory_on_domain_k : capabilities_unknown_k) | //
         (FU_WITH_PLACE_HUGE_PAGES_ON_DOMAIN ? capability_place_huge_pages_on_domain_k : capabilities_unknown_k) |
-        (FU_WITH_COLOCATE_POOLS_ON_DOMAIN ? capability_colocate_pools_on_domain_k : capabilities_unknown_k);
+        (FU_WITH_COLOCATE_POOLS_ON_DOMAIN ? capability_colocate_pools_on_domain_k : capabilities_unknown_k) |
+        (FU_DETECT_ATOMIC_WAIT_ ? capability_interruptible_sleep_k : capabilities_unknown_k);
 }
 
 } // namespace forkunion

--- a/include/forkunion/distributed.hpp
+++ b/include/forkunion/distributed.hpp
@@ -505,6 +505,9 @@ struct colocated_pool {
 
         // Stop all threads and wait for them to finish
         mood_.store(mood_t::die_k, std::memory_order_release);
+#if FU_DETECT_ATOMIC_WAIT_
+        mood_.notify_all();
+#endif
 
         caller_exclusivity_t const exclusivity = caller_exclusivity();
         bool const use_caller_thread = exclusivity == caller_inclusive_k;
@@ -533,16 +536,12 @@ struct colocated_pool {
     }
 
     /**
-     *  @brief Transitions "workers" to a sleeping state, waiting for a wake-up call.
-     *  @param[in] wake_up_periodicity_micros How often to check for new work in microseconds.
+     *  @brief Transitions workers to a low-power sleep until the next dispatch.
+     *  @param[in] wake_up_periodicity_micros Maximum fallback wake interval in microseconds.
      *  @note Can only be called @b between the tasks for a single thread. No synchronization is performed.
      *
-     *  This function may be used in some batch-processing operations when we clearly understand
-     *  that the next task won't be arriving for a while and power can be saved without major
-     *  latency penalties.
-     *
-     *  It may also be used in a high-level Python or JavaScript library offloading some parallel
-     *  operations to an underlying C++ engine, where latency is irrelevant.
+     *  C++20 builds wake sleeping workers directly on the next dispatch. C++17 builds poll at the
+     *  supplied interval, which caps their wake latency.
      */
     void sleep(std::size_t wake_up_periodicity_micros) noexcept {
         assert(wake_up_periodicity_micros > 0 && "Sleep length must be positive");
@@ -654,13 +653,11 @@ struct colocated_pool {
         // on `caller_inclusive_k` pools, where its slice runs inside `unsafe_join`.
         threads_to_sync_.store(threads, std::memory_order_relaxed);
 
-        // We are most likely already "grinding", but in the unlikely case we are not,
-        // let's wake up from the "chilling" state with relaxed semantics. Assuming the sleeping
-        // logic for the workers also checks the epoch counter, no synchronization is needed and
-        // no immediate wake-up is required.
+        // A dispatch moves workers out of `chill_k`, publishes its epoch, then wakes their atomic
+        // waits. `compare_exchange_strong` ensures a sleeping pool always makes this transition.
         mood_t may_be_chilling = mood_t::chill_k;
-        bool const was_chilling = mood_.compare_exchange_weak( //
-            may_be_chilling, mood_t::grind_k,                  //
+        bool const was_chilling = mood_.compare_exchange_strong( //
+            may_be_chilling, mood_t::grind_k,                    //
             std::memory_order_relaxed, std::memory_order_relaxed);
         generation_t const generation = static_cast<generation_t>(epoch_.fetch_add(1, std::memory_order_release) + 1);
 
@@ -685,6 +682,9 @@ struct colocated_pool {
         }
 #else
         fu_unused_(was_chilling); // ? No runnable-class nudge on Darwin or Windows
+#endif
+#if FU_DETECT_ATOMIC_WAIT_
+        if (was_chilling) mood_.notify_all();
 #endif
         return generation;
     }
@@ -845,20 +845,22 @@ struct colocated_pool {
         }
         thread_index_t const global_thread_index = pool->first_thread_ + local_thread_index;
 
-        // Run the infinite loop, using Linux-specific napping mechanism
+        // Run the infinite loop, waiting on the hot epoch while active.
         epoch_index_t last_epoch = 0;
         epoch_index_t new_epoch;
         while (true) {
             // Wait for either: a new ticket or a stop flag
-            // Two independent lines guard this loop - arm the hot one (`epoch_`, bumped by a dispatch)
-            // and let the waiter's timeout cap bound how late a rare `mood_` change is noticed.
             while ((new_epoch = pool->epoch_.load(std::memory_order_acquire)) == last_epoch &&
                    (mood = pool->mood_.load(std::memory_order_acquire)) == mood_t::grind_k)
                 micro_yield(pool->epoch_, last_epoch, global_thread_index);
 
             if (fu_unlikely_(mood == mood_t::die_k)) break;
             if (fu_unlikely_(mood == mood_t::chill_k) && (new_epoch == last_epoch)) {
+#if FU_DETECT_ATOMIC_WAIT_
+                pool->mood_.wait(mood_t::chill_k, std::memory_order_acquire);
+#else
                 sleep_for_micros(pool->sleep_length_micros_);
+#endif
                 continue;
             }
 

--- a/include/forkunion/distributed.hpp
+++ b/include/forkunion/distributed.hpp
@@ -169,6 +169,8 @@ struct colocated_pool {
     thread_index_t first_thread_ {0};
     /** @brief How long to nap in microseconds while `chill_k`, waiting for work. */
     std::size_t sleep_length_micros_ {0};
+    /** @brief Whether `sleep` blocks on the dispatch notification instead of polling. */
+    bool interruptible_sleep_ {false};
 
     using char16_name_t = char[16]; // ? Fixed-size thread name buffer, for POSIX thread naming
     /** @brief Thread name buffer applied to each worker for POSIX/OS naming. */
@@ -206,10 +208,17 @@ struct colocated_pool {
     colocated_pool &operator=(colocated_pool &&) = delete;
     colocated_pool &operator=(colocated_pool const &) = delete;
 
-    explicit colocated_pool(char const *name = "forkunion") noexcept { rename(name); }
+    explicit colocated_pool(char const *name = "forkunion", bool const interruptible_sleep = false) noexcept
+        : interruptible_sleep_(interruptible_sleep) {
+        rename(name);
+    }
+
+    /** @brief Selects direct dispatch wakeups; call before spawning workers. */
+    void set_interruptible_sleep(bool const enabled) noexcept { interruptible_sleep_ = enabled; }
 
     /** @brief Replaces the pool's name; only threads spawned after the call pick it up. */
     void rename(char const *name) noexcept {
+
         // Accept NULL or empty names by falling back to a sensible default
         char const *effective_name = (name && name[0] != '\0') ? name : "forkunion";
         std::size_t const source_length = std::strlen(effective_name);
@@ -506,7 +515,7 @@ struct colocated_pool {
         // Stop all threads and wait for them to finish
         mood_.store(mood_t::die_k, std::memory_order_release);
 #if FU_DETECT_ATOMIC_WAIT_
-        mood_.notify_all();
+        if (interruptible_sleep_) mood_.notify_all();
 #endif
 
         caller_exclusivity_t const exclusivity = caller_exclusivity();
@@ -540,8 +549,8 @@ struct colocated_pool {
      *  @param[in] wake_up_periodicity_micros Maximum fallback wake interval in microseconds.
      *  @note Can only be called @b between the tasks for a single thread. No synchronization is performed.
      *
-     *  C++20 builds wake sleeping workers directly on the next dispatch. C++17 builds poll at the
-     *  supplied interval, which caps their wake latency.
+     *  When constructed with `capability_interruptible_sleep_k`, workers wake directly on dispatch.
+     *  Otherwise, workers poll at the supplied interval, which caps their wake latency.
      */
     void sleep(std::size_t wake_up_periodicity_micros) noexcept {
         assert(wake_up_periodicity_micros > 0 && "Sleep length must be positive");
@@ -684,7 +693,7 @@ struct colocated_pool {
         fu_unused_(was_chilling); // ? No runnable-class nudge on Darwin or Windows
 #endif
 #if FU_DETECT_ATOMIC_WAIT_
-        if (was_chilling) mood_.notify_all();
+        if (interruptible_sleep_ && was_chilling) mood_.notify_all();
 #endif
         return generation;
     }
@@ -857,10 +866,10 @@ struct colocated_pool {
             if (fu_unlikely_(mood == mood_t::die_k)) break;
             if (fu_unlikely_(mood == mood_t::chill_k) && (new_epoch == last_epoch)) {
 #if FU_DETECT_ATOMIC_WAIT_
-                pool->mood_.wait(mood_t::chill_k, std::memory_order_acquire);
-#else
-                sleep_for_micros(pool->sleep_length_micros_);
+                if (pool->interruptible_sleep_) pool->mood_.wait(mood_t::chill_k, std::memory_order_acquire);
+                else
 #endif
+                    sleep_for_micros(pool->sleep_length_micros_);
                 continue;
             }
 
@@ -1176,6 +1185,8 @@ struct distributed_pool {
     thread_index_t threads_count_ {0};
     /** @brief Whether the caller thread is counted as one of the contributors. */
     caller_exclusivity_t exclusivity_ {caller_inclusive_k};
+    /** @brief Whether child pools wait for a dispatch notification instead of polling. */
+    bool interruptible_sleep_ {false};
     /**
      *  @brief One pinned sub-pool per compute domain, in one flat contiguous array.
      *
@@ -1195,9 +1206,10 @@ struct distributed_pool {
     distributed_pool &operator=(distributed_pool &&) = delete;
     distributed_pool &operator=(distributed_pool const &) = delete;
 
-    distributed_pool() noexcept : distributed_pool("forkunion") {}
+    distributed_pool() noexcept : distributed_pool("forkunion", false) {}
 
-    explicit distributed_pool(char const *name) noexcept {
+    explicit distributed_pool(char const *name, bool const interruptible_sleep = false) noexcept
+        : interruptible_sleep_(interruptible_sleep) {
         // Accept null or empty names by falling back to a sensible default
         char const *effective_name = (name && name[0] != '\0') ? name : "forkunion";
         std::size_t const source_length = std::strlen(effective_name);
@@ -1310,8 +1322,10 @@ struct distributed_pool {
 
         colocations_t colocations(allocator);
         if (!colocations.try_resize(colocations_count)) return false; // ! Allocation failed
-        for (index_t compute_domain_index = 0; compute_domain_index < colocations_count; ++compute_domain_index)
+        for (index_t compute_domain_index = 0; compute_domain_index < colocations_count; ++compute_domain_index) {
+            colocations[compute_domain_index].set_interruptible_sleep(interruptible_sleep_);
             colocations[compute_domain_index].rename(name_);
+        }
 
         auto reset_on_failure = [&]() noexcept {
             for (index_t compute_domain_index = 0; compute_domain_index < colocations_count; ++compute_domain_index)

--- a/include/forkunion/flat.hpp
+++ b/include/forkunion/flat.hpp
@@ -182,6 +182,8 @@ class flat_pool {
     caller_exclusivity_t exclusivity_ {caller_inclusive_k};
     /** @brief How long to nap in microseconds while `chill_k`, waiting for work. */
     std::size_t sleep_length_micros_ {0};
+    /** @brief Whether `sleep` blocks on the dispatch notification instead of polling. */
+    bool interruptible_sleep_ {false};
     /** @brief Lifecycle switch between spinning (`grind_k`), sleeping (`chill_k`), and exiting (`die_k`). */
     alignas(alignment_k) std::atomic<mood_t> mood_ {mood_t::grind_k};
 
@@ -201,7 +203,9 @@ class flat_pool {
     flat_pool &operator=(flat_pool &&) = delete;
     flat_pool &operator=(flat_pool const &) = delete;
 
-    flat_pool(allocator_t const &alloc = {}) noexcept : allocator_(alloc) {}
+    flat_pool(allocator_t const &alloc = {}, bool const interruptible_sleep = false) noexcept
+        : allocator_(alloc), interruptible_sleep_(interruptible_sleep) {}
+    explicit flat_pool(bool const interruptible_sleep) noexcept : flat_pool({}, interruptible_sleep) {}
     ~flat_pool() noexcept { terminate(); }
 
     /**
@@ -358,7 +362,7 @@ class flat_pool {
         // Notify all worker threads...
         mood_.store(mood_t::die_k, std::memory_order_release);
 #if FU_DETECT_ATOMIC_WAIT_
-        mood_.notify_all();
+        if (interruptible_sleep_) mood_.notify_all();
 #endif
 
         // ... and wait for them to finish
@@ -380,8 +384,8 @@ class flat_pool {
      *  @param[in] wake_up_periodicity_micros Maximum fallback wake interval in microseconds.
      *  @note Can only be called @b between the tasks for a single thread. No synchronization is performed.
      *
-     *  C++20 builds wake sleeping workers directly on the next dispatch. C++17 builds poll at the
-     *  supplied interval, which caps their wake latency.
+     *  When constructed with `capability_interruptible_sleep_k`, workers wake directly on dispatch.
+     *  Otherwise, workers poll at the supplied interval, which caps their wake latency.
      */
     void sleep(std::size_t wake_up_periodicity_micros) noexcept {
         assert(wake_up_periodicity_micros > 0 && "Sleep length must be positive");
@@ -480,7 +484,7 @@ class flat_pool {
             std::memory_order_relaxed, std::memory_order_relaxed);
         generation_t const generation = static_cast<generation_t>(epoch_.fetch_add(1, std::memory_order_release) + 1);
 #if FU_DETECT_ATOMIC_WAIT_
-        if (was_chilling) mood_.notify_all();
+        if (interruptible_sleep_ && was_chilling) mood_.notify_all();
 #else
         fu_unused_(was_chilling);
 #endif
@@ -609,10 +613,10 @@ class flat_pool {
             if (fu_unlikely_(mood == mood_t::die_k)) break;
             if (fu_unlikely_(mood == mood_t::chill_k) && (new_epoch == last_epoch)) {
 #if FU_DETECT_ATOMIC_WAIT_
-                mood_.wait(mood_t::chill_k, std::memory_order_acquire);
-#else
-                std::this_thread::sleep_for(std::chrono::microseconds(sleep_length_micros_));
+                if (interruptible_sleep_) mood_.wait(mood_t::chill_k, std::memory_order_acquire);
+                else
 #endif
+                    std::this_thread::sleep_for(std::chrono::microseconds(sleep_length_micros_));
                 continue;
             }
 

--- a/include/forkunion/flat.hpp
+++ b/include/forkunion/flat.hpp
@@ -357,6 +357,9 @@ class flat_pool {
 
         // Notify all worker threads...
         mood_.store(mood_t::die_k, std::memory_order_release);
+#if FU_DETECT_ATOMIC_WAIT_
+        mood_.notify_all();
+#endif
 
         // ... and wait for them to finish
         thread_index_t const worker_threads = threads_count_ - use_caller_thread;
@@ -373,16 +376,12 @@ class flat_pool {
     }
 
     /**
-     *  @brief Transitions "workers" to a sleeping state, waiting for a wake-up call.
-     *  @param[in] wake_up_periodicity_micros How often to check for new work in microseconds.
+     *  @brief Transitions workers to a low-power sleep until the next dispatch.
+     *  @param[in] wake_up_periodicity_micros Maximum fallback wake interval in microseconds.
      *  @note Can only be called @b between the tasks for a single thread. No synchronization is performed.
      *
-     *  This function may be used in some batch-processing operations when we clearly understand
-     *  that the next task won't be arriving for a while and power can be saved without major
-     *  latency penalties.
-     *
-     *  It may also be used in a high-level Python or JavaScript library offloading some parallel
-     *  operations to an underlying C++ engine, where latency is irrelevant.
+     *  C++20 builds wake sleeping workers directly on the next dispatch. C++17 builds poll at the
+     *  supplied interval, which caps their wake latency.
      */
     void sleep(std::size_t wake_up_periodicity_micros) noexcept {
         assert(wake_up_periodicity_micros > 0 && "Sleep length must be positive");
@@ -473,15 +472,19 @@ class flat_pool {
         // on `caller_inclusive_k` pools, where its slice runs inside `unsafe_join`.
         threads_to_sync_.store(threads, std::memory_order_relaxed);
 
-        // We are most likely already "grinding", but in the unlikely case we are not,
-        // let's wake up from the "chilling" state with relaxed semantics. Assuming the sleeping
-        // logic for the workers also checks the epoch counter, no synchronization is needed and
-        // no immediate wake-up is required.
+        // A dispatch moves workers out of `chill_k`, publishes its epoch, then wakes their atomic
+        // waits. `compare_exchange_strong` ensures a sleeping pool always makes this transition.
         mood_t may_be_chilling = mood_t::chill_k;
-        mood_.compare_exchange_weak(          //
-            may_be_chilling, mood_t::grind_k, //
+        bool const was_chilling = mood_.compare_exchange_strong( //
+            may_be_chilling, mood_t::grind_k,                    //
             std::memory_order_relaxed, std::memory_order_relaxed);
-        return static_cast<generation_t>(epoch_.fetch_add(1, std::memory_order_release) + 1);
+        generation_t const generation = static_cast<generation_t>(epoch_.fetch_add(1, std::memory_order_release) + 1);
+#if FU_DETECT_ATOMIC_WAIT_
+        if (was_chilling) mood_.notify_all();
+#else
+        fu_unused_(was_chilling);
+#endif
+        return generation;
     }
 
     /**
@@ -605,7 +608,11 @@ class flat_pool {
 
             if (fu_unlikely_(mood == mood_t::die_k)) break;
             if (fu_unlikely_(mood == mood_t::chill_k) && (new_epoch == last_epoch)) {
+#if FU_DETECT_ATOMIC_WAIT_
+                mood_.wait(mood_t::chill_k, std::memory_order_acquire);
+#else
                 std::this_thread::sleep_for(std::chrono::microseconds(sleep_length_micros_));
+#endif
                 continue;
             }
 

--- a/include/forkunion/types.hpp
+++ b/include/forkunion/types.hpp
@@ -358,6 +358,13 @@
 #include <concepts> // `std::same_as`, `std::invocable`
 #include <bit>      // `std::popcount`
 #endif
+/* `std::atomic::wait`/`notify_all` give a sleeping pool an event-driven wake path. Keep the
+ * C++17 headers usable: their timed sleep remains the portable fallback. */
+#if FU_DETECT_CPP_20_ && defined(__cpp_lib_atomic_wait) && __cpp_lib_atomic_wait >= 201907L
+#define FU_DETECT_ATOMIC_WAIT_ 1
+#else
+#define FU_DETECT_ATOMIC_WAIT_ 0
+#endif
 
 #if FU_DETECT_CPP_17_
 #define FU_MAYBE_UNUSED_ [[maybe_unused]]

--- a/include/forkunion/types.hpp
+++ b/include/forkunion/types.hpp
@@ -358,8 +358,8 @@
 #include <concepts> // `std::same_as`, `std::invocable`
 #include <bit>      // `std::popcount`
 #endif
-/* `std::atomic::wait`/`notify_all` give a sleeping pool an event-driven wake path. Keep the
- * C++17 headers usable: their timed sleep remains the portable fallback. */
+/* `std::atomic::wait`/`notify_all` make direct wakeups possible; a pool enables them through
+ * `capability_interruptible_sleep_k`. */
 #if FU_DETECT_CPP_20_ && defined(__cpp_lib_atomic_wait) && __cpp_lib_atomic_wait >= 201907L
 #define FU_DETECT_ATOMIC_WAIT_ 1
 #else
@@ -610,6 +610,9 @@ enum capabilities_t : unsigned int {
      */
     capability_risc5_zicbom_k = 1 << 17,
 
+    /** Sleeping workers wait for a dispatch notification instead of polling. Built when C++20 atomics support it. */
+    capability_interruptible_sleep_k = 1 << 18,
+
     /** Composite mask of every busy-wait waiter bit above, to enumerate the ones a machine offers. */
     capability_any_yield_k = capability_x86_pause_k | capability_x86_tpause_k | capability_arm64_yield_k |
                              capability_arm64_wfet_k | capability_risc5_pause_k | capability_risc5_wrs_k,
@@ -667,6 +670,7 @@ constexpr char const *capability_name(capabilities_t const capability) noexcept 
     case capability_place_huge_pages_on_domain_k: return "place_huge_pages_on_domain";
     case capability_huge_transparent_pages_k: return "huge_transparent_pages";
     case capability_colocate_pools_on_domain_k: return "colocate_pools_on_domain";
+    case capability_interruptible_sleep_k: return "interruptible_sleep";
     default: return nullptr;
     }
 }

--- a/rust/forkunion/scheduling.rs
+++ b/rust/forkunion/scheduling.rs
@@ -173,13 +173,13 @@ impl ThreadPool {
             name,
             threads,
             exclusivity,
-            Capabilities::ALL,
+            Capabilities(Capabilities::ALL.0 & !Capabilities::INTERRUPTIBLE_SLEEP.0),
         )
     }
 
-    /// As [`try_named_spawn_with_exclusivity`](Self::try_named_spawn_with_exclusivity), but constrains
-    /// the pool to `allowed`: clear a waiter bit to force a lower-priority busy-wait, or clear
-    /// [`Capabilities::PLACE_MEMORY_ON_DOMAIN`] to force the flat (non-NUMA) pool.
+    /// the pool to `allowed`: clear a waiter bit to force a lower-priority busy-wait, clear
+    /// [`Capabilities::PLACE_MEMORY_ON_DOMAIN`] to force the flat (non-NUMA) pool, or include
+    /// [`Capabilities::INTERRUPTIBLE_SLEEP`] to wake sleeping workers directly on dispatch.
     pub fn try_named_spawn_with_capabilities(
         topology: &Topology,
         name: Option<&str>,
@@ -250,11 +250,12 @@ impl ThreadPool {
             compute_domain_index,
             threads,
             exclusivity,
-            Capabilities::ALL,
+            Capabilities(Capabilities::ALL.0 & !Capabilities::INTERRUPTIBLE_SLEEP.0),
         )
     }
 
     /// As [`try_spawn_on`](Self::try_spawn_on), but constrains the colocated pool to `allowed`.
+    /// Include [`Capabilities::INTERRUPTIBLE_SLEEP`] to wake sleeping workers directly on dispatch.
     pub fn try_spawn_on_with_capabilities(
         topology: &Topology,
         compute_domain_index: usize,
@@ -421,8 +422,8 @@ impl ThreadPool {
 
     /// Transitions worker threads to a low-power sleep state until the next dispatch.
     ///
-    /// The bundled C++20 core wakes workers directly on the next dispatch. `micros` remains a
-    /// fallback wake interval for C++17 consumers.
+    /// Include [`Capabilities::INTERRUPTIBLE_SLEEP`] in the pool's allowed capabilities to wake
+    /// workers directly on the next dispatch. Without it, `micros` is the wake-up polling interval.
     ///
     /// # Arguments
     ///
@@ -1264,6 +1265,31 @@ mod tests {
         let pool = spawn(&topology, 2);
         assert_eq!(pool.threads_count(), 2);
         assert!(pool.compute_domains_count() > 0);
+    }
+
+    #[cfg_attr(miri, ignore)]
+    #[test]
+    fn interruptible_sleep_is_opt_in() {
+        let topology = Topology::new().unwrap();
+        let default = spawn(&topology, 2);
+        assert!(!default
+            .capabilities()
+            .contains(Capabilities::INTERRUPTIBLE_SLEEP));
+
+        let enabled = ThreadPool::try_named_spawn_with_capabilities(
+            &topology,
+            None,
+            2,
+            CallerExclusivity::Inclusive,
+            Capabilities::ALL,
+        )
+        .unwrap();
+        assert_eq!(
+            enabled
+                .capabilities()
+                .contains(Capabilities::INTERRUPTIBLE_SLEEP),
+            comptime_capabilities().contains(Capabilities::INTERRUPTIBLE_SLEEP)
+        );
     }
 
     #[cfg_attr(miri, ignore)]

--- a/rust/forkunion/scheduling.rs
+++ b/rust/forkunion/scheduling.rs
@@ -419,11 +419,10 @@ impl ThreadPool {
         unsafe { fu_pool_locate_thread_in(self.inner, global_thread_index, compute_domain_index) }
     }
 
-    /// Transitions worker threads to a power-saving sleep state.
+    /// Transitions worker threads to a low-power sleep state until the next dispatch.
     ///
-    /// This function places worker threads into a low-power sleep state when no work
-    /// is available for extended periods. Threads will periodically check for new work
-    /// at the specified interval.
+    /// The bundled C++20 core wakes workers directly on the next dispatch. `micros` remains a
+    /// fallback wake interval for C++17 consumers.
     ///
     /// # Arguments
     ///

--- a/rust/forkunion/topology.rs
+++ b/rust/forkunion/topology.rs
@@ -117,6 +117,8 @@ impl Capabilities {
     pub const HUGE_TRANSPARENT_PAGES: Capabilities = Capabilities(1 << 13);
     /// The domain-aware `colocated_pool` and `distributed_pool` are compiled in.
     pub const COLOCATE_POOLS_ON_DOMAIN: Capabilities = Capabilities(1 << 14);
+    /// Sleeping workers wait for a dispatch notification instead of polling.
+    pub const INTERRUPTIBLE_SLEEP: Capabilities = Capabilities(1 << 18);
 
     /// All-ones allow-mask: pass to a pool constructor to disable capability filtering.
     pub const ALL: Capabilities = Capabilities(u32::MAX);

--- a/scripts/test.cpp
+++ b/scripts/test.cpp
@@ -5,6 +5,8 @@
 #include <vector>      // `std::vector`
 #include <algorithm>   // `std::sort`
 #include <type_traits> // `std::is_integral`, `std::is_enum`
+#include <chrono>      // `std::chrono::milliseconds`
+#include <thread>      // `std::this_thread::sleep_for`
 
 #include <forkunion.hpp>
 
@@ -1085,6 +1087,13 @@ static void test_sleep_wake() noexcept {
 
     std::vector<aligned_visit_t> visited(default_parallel_tasks_k);
     std::atomic<std::size_t> counter {0};
+#if FU_DETECT_ATOMIC_WAIT_
+    pool.sleep(100000);
+    std::this_thread::sleep_for(std::chrono::milliseconds(10));
+    auto const started = std::chrono::steady_clock::now();
+    pool.for_n(default_parallel_tasks_k, [](std::size_t) noexcept {});
+    expect(std::chrono::steady_clock::now() - started < std::chrono::milliseconds(50));
+#endif
     for (std::size_t batch = 0; batch != 4; ++batch) {
         pool.sleep(100); // ? Nap in 100 us intervals until the next dispatch
         counter.store(0, std::memory_order_relaxed);

--- a/zig/forkunion/scheduling.zig
+++ b/zig/forkunion/scheduling.zig
@@ -69,6 +69,12 @@ extern fn fu_fabric_memory_levels_count(fabric: *anyopaque) usize;
 pub const Pool = struct {
     handle: *anyopaque,
 
+    fn defaultCapabilities() Capabilities {
+        var allowed = Capabilities.all();
+        allowed.interruptible_sleep = false;
+        return allowed;
+    }
+
     /// Creates a new thread pool
     pub fn init(topo: Topology, thread_count: usize, exclusivity: CallerExclusivity) Error!Pool {
         return initNamed(topo, null, thread_count, exclusivity);
@@ -81,11 +87,12 @@ pub const Pool = struct {
         thread_count: usize,
         exclusivity: CallerExclusivity,
     ) Error!Pool {
-        return initNamedWithCapabilities(topo, name, thread_count, exclusivity, Capabilities.all());
+        return initNamedWithCapabilities(topo, name, thread_count, exclusivity, defaultCapabilities());
     }
 
     /// As `initNamed`, but constrains the pool to `allowed`: clear a waiter bit to force a
-    /// lower-priority busy-wait, or clear `place_memory_on_domain` to force the flat (non-NUMA) pool.
+    /// lower-priority busy-wait, clear `place_memory_on_domain` to force the flat (non-NUMA) pool,
+    /// or include `interruptible_sleep` to wake sleeping workers directly on dispatch.
     pub fn initNamedWithCapabilities(
         topo: Topology,
         name: ?[]const u8,
@@ -116,10 +123,11 @@ pub const Pool = struct {
     /// single thread with the generation-token API. On builds without NUMA, only compute
     /// domain 0 is valid.
     pub fn spawnOn(topo: Topology, compute_domain_index: usize, thread_count: usize, exclusivity: CallerExclusivity) Error!Pool {
-        return spawnOnWithCapabilities(topo, compute_domain_index, thread_count, exclusivity, Capabilities.all());
+        return spawnOnWithCapabilities(topo, compute_domain_index, thread_count, exclusivity, defaultCapabilities());
     }
 
-    /// As `spawnOn`, but constrains the colocated pool to `allowed`.
+    /// As `spawnOn`, but constrains the colocated pool to `allowed`. Include `interruptible_sleep`
+    /// to wake sleeping workers directly on dispatch.
     pub fn spawnOnWithCapabilities(
         topo: Topology,
         compute_domain_index: usize,
@@ -180,7 +188,8 @@ pub const Pool = struct {
         fu_pool_terminate(self.handle);
     }
 
-    /// Puts worker threads into power-saving sleep state
+    /// Puts worker threads into power-saving sleep state. Include `interruptible_sleep` in the
+    /// pool's allowed capabilities to wake workers directly on the next dispatch.
     pub fn sleep(self: *const Pool, microseconds: usize) void {
         fu_pool_sleep(self.handle, microseconds);
     }
@@ -574,9 +583,20 @@ test "pool capabilities reflect the build" {
     defer pool.deinit();
     const full: u32 = @bitCast(pool.capabilities());
 
+    // Default helpers leave direct wakeups off; an explicit all-ones mask enables them when this
+    // build has C++20 atomic waits.
+    try std.testing.expect(!pool.capabilities().interruptible_sleep);
+    var interruptible_pool = try Pool.initNamedWithCapabilities(topo, null, 2, .inclusive, Capabilities.all());
+    defer interruptible_pool.deinit();
+    try std.testing.expectEqual(
+        topology.comptimeCapabilities().interruptible_sleep,
+        interruptible_pool.capabilities().interruptible_sleep,
+    );
+
     // Clearing a bit in the allow-mask must clear it in the effective set - the mask can
     // only subtract: forcing off `place_memory_on_domain` demotes a NUMA pool to the flat pool.
     var flat_mask = Capabilities.all();
+    flat_mask.interruptible_sleep = false;
     flat_mask.place_memory_on_domain = false;
     var flat_pool = try Pool.initNamedWithCapabilities(topo, null, 2, .inclusive, flat_mask);
     defer flat_pool.deinit();

--- a/zig/forkunion/topology.zig
+++ b/zig/forkunion/topology.zig
@@ -102,8 +102,12 @@ pub const Capabilities = packed struct(u32) {
     huge_transparent_pages: bool = false,
     /// The domain-aware `colocated_pool` and `distributed_pool` are compiled in
     colocate_pools_on_domain: bool = false,
+    // Bits 15–17 are C++ cache-hint capabilities not exposed by the Zig wrapper.
+    _cache_hint_capabilities: u3 = 0,
+    /// Sleeping workers wait for a dispatch notification instead of polling.
+    interruptible_sleep: bool = false,
 
-    _unused: u17 = 0,
+    _unused: u13 = 0,
 
     /// All-ones allow-mask: pass to a pool constructor to disable capability filtering.
     pub fn all() Capabilities {


### PR DESCRIPTION
Adds support for "interruptible sleep" in worker pools, allowing idle worker threads to efficiently wait for dispatch notifications using C++20 atomic wait/notify primitives instead of polling. This feature is conditionally enabled based on platform and build capabilities, and is exposed via a new capability flag. The changes update both the core pool logic and the public API and documentation to reflect this new behavior.

**Interruptible sleep support:**

* Introduced a new capability flag `fu_capability_interruptible_sleep_k` to indicate support for direct dispatch wakeups using atomic wait/notify.
* Updated pool constructors (`flat_pool`, `colocated_pool`, `distributed_pool`) and internal logic to propagate and honor the `interruptible_sleep` option, including new member variables and constructor parameters.

**Worker sleep/wake logic:**

* Modified the worker sleep loop to use `std::atomic::wait`/`notify_all` for waking idle threads directly when `interruptible_sleep` is enabled, falling back to polling otherwise.
* Ensured that dispatch and shutdown paths use `notify_all` to wake sleeping workers when necessary.

* Clarified the behavior of `fu_pool_sleep` and related methods in the public header documentation to describe the new interruptible sleep semantics.

**Internal consistency and propagation:**

* Ensured the `interruptible_sleep` flag is consistently propagated through all pool types and their subcomponents, including when constructing colocated and distributed pools.